### PR TITLE
Updated Marathon REST API link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # marathon-client [![Build Status](https://travis-ci.org/mohitsoni/marathon-client.png)](https://travis-ci.org/mohitsoni/marathon-client)
 
-This project is a Java library for communicating with Marathon API. At this point this library supports version v2 of Marathon API, please refer [docs](https://github.com/mesosphere/marathon/blob/master/REST.md) for more details.
+This project is a Java library for communicating with Marathon API. At this point this library supports version v2 of Marathon API, please refer [docs](https://mesosphere.github.io/marathon/docs/rest-api.html) for more details.
 
 ## Using marathon-client in your maven project
 


### PR DESCRIPTION
Current address https://github.com/mesosphere/marathon/blob/master/REST.md gives 404. 
