### PR TITLE
Expose the HTTP status code of the failure.

### DIFF
--- a/src/main/java/mesosphere/marathon/client/utils/MarathonException.java
+++ b/src/main/java/mesosphere/marathon/client/utils/MarathonException.java
@@ -9,8 +9,15 @@ public class MarathonException extends Exception {
 		this.status = status;
 		this.message = message;
 	}
-	
-	@Override
+
+    /**
+     * Gets the HTTP status code of the failure, such as 404.
+     */
+    public int getStatus() {
+        return status;
+    }
+
+    @Override
 	public String getMessage() {
 		return message + " (http status: " + status + ")";
 	}


### PR DESCRIPTION
... so that for example 404 (not found) cannot be processed differently
from 503 (server temporarily unavailable)